### PR TITLE
Cache all days, not only today

### DIFF
--- a/.github/workflows/go-format.yml
+++ b/.github/workflows/go-format.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.20'
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.20'
 
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v1

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Flags:
 Requires Go 1.20 or higher.
 
 ```sh
-go install github.com/jilleJr/namnsdag/v2@latest
+go install github.com/jilleJr/namnsdag/v3@latest
 ```
 
 ## License

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/jilleJr/namnsdag/v2/pkg/namnsdag"
+	"github.com/jilleJr/namnsdag/v3/pkg/namnsdag"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,11 +37,13 @@ var (
 	colorPrefix = color.New(color.FgHiBlack)
 	colorText   = color.New(color.FgYellow)
 	colorStatus = color.New(color.FgHiBlack, color.Italic)
+	colorError  = color.New(color.FgRed)
 
 	colorNameOfficial         = color.New(color.FgHiCyan)
 	colorNameUnofficial       = color.New(color.FgCyan, color.Italic)
 	colorNameUnofficialSymbol = color.New(color.FgMagenta, color.Italic)
 	colorNameDelimiter        = color.New(color.FgHiBlack)
+	colorNameNone             = color.New(color.FgRed, color.Italic)
 
 	rootFlags = struct {
 		noFetch      bool
@@ -59,12 +61,18 @@ var rootCmd = &cobra.Command{
 When run, it will query https://www.dagensnamnsdag.nu/ to obtain today's names,
 and cache the results inside ~/.cache/namnsdag/`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		names, err := loadOrFetchNames()
+		namesPerDay, err := loadOrFetchNames()
 		if err != nil {
 			return err
 		}
+		dom := namnsdag.NewDoMFromTime(time.Now())
+		names := namesPerDay[dom]
 		if rootFlags.noUnofficial {
 			names = filterOnlyOfficial(names)
+		}
+		if len(names) == 0 {
+			writeColored(fmt.Sprintf("Today's names: %s", colorNameNone.Sprint("no names found for today")))
+			return nil
 		}
 		writeColored(fmt.Sprintf("Today's names: %s", joinNames(names)))
 		return nil
@@ -95,35 +103,58 @@ func joinNames(names []namnsdag.Name) string {
 	return sb.String()
 }
 
-func loadOrFetchNames() ([]namnsdag.Name, error) {
+func loadOrFetchNames() (map[namnsdag.DoM][]namnsdag.Name, error) {
 	if rootFlags.noCache && rootFlags.noFetch {
 		return nil, errors.New("cannot use --no-cache and --no-fetch at the same time")
 	}
 
-	today := time.Now()
+	var cache namnsdag.Cache
 
 	if !rootFlags.noCache {
-		names, err := namnsdag.LoadCache(today)
+		c, err := namnsdag.LoadCache()
 		if err != nil {
 			return nil, fmt.Errorf("load cached names: %w", err)
 		}
-		if names != nil {
-			return names, nil
-		}
-		if rootFlags.noFetch {
-			return nil, errors.New("none or outdated cache, and skipping fetch because --no-fetch was supplied")
-		}
+		cache = c
 	}
 
-	colorStatus.Println("Fetching names from " + namnsdag.URL)
-	names, err := namnsdag.FetchToday()
+	isCacheValid := len(cache.NamesPerDay) > 0
+	if isCacheValid && rootFlags.noFetch {
+		return cache.NamesPerDay, nil
+	}
+
+	isCacheOutdated := !isCacheValid || cache.UpdatedAt.Before(time.Now().Truncate(24*time.Hour))
+	if isCacheOutdated && rootFlags.noFetch {
+		return nil, errors.New("none or outdated cache, and skipping fetch because --no-fetch was supplied")
+	}
+
+	if !isCacheOutdated {
+		return cache.NamesPerDay, nil
+	}
+
+	req := namnsdag.Request{ETag: cache.ETag}
+	if !isCacheValid {
+		req.ETag = ""
+	}
+
+	colorStatus.Printf("Fetching names from %s... ", namnsdag.URL)
+	resp, err := namnsdag.Fetch(req)
+	if errors.Is(err, namnsdag.ErrHTTPNotModified) && isCacheValid {
+		colorStatus.Println("cache is up-to-date")
+		return cache.NamesPerDay, nil
+	}
 	if err != nil {
+		colorError.Println("error")
 		return nil, fmt.Errorf("fetch names: %w", err)
 	}
-	if err := namnsdag.SaveCache(today, names); err != nil {
+	colorStatus.Printf("fetched %d names\n", len(resp.Names))
+	cache.SetNames(resp.Names)
+	cache.UpdatedAt = time.Now()
+	cache.ETag = resp.ETag
+	if err := namnsdag.SaveCache(cache); err != nil {
 		return nil, fmt.Errorf("cache names: %w", err)
 	}
-	return names, nil
+	return cache.NamesPerDay, nil
 }
 
 func filterOnlyOfficial(names []namnsdag.Name) []namnsdag.Name {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: CC0-1.0
 
-module github.com/jilleJr/namnsdag/v2
+module github.com/jilleJr/namnsdag/v3
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@
 // cmd package.
 package main
 
-import "github.com/jilleJr/namnsdag/v2/cmd"
+import "github.com/jilleJr/namnsdag/v3/cmd"
 
 func main() {
 	cmd.Execute()

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@
 // You should have received a copy of the GNU General Public License along
 // with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// Package main is the entrypoint for this module. It launches the CLI from the
+// cmd package.
 package main
 
 import "github.com/jilleJr/namnsdag/v2/cmd"

--- a/pkg/namnsdag/cache.go
+++ b/pkg/namnsdag/cache.go
@@ -172,7 +172,7 @@ func CacheFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, "latest.json"), nil
+	return filepath.Join(dir, "cache@v3.json"), nil
 }
 
 func cacheDir() (string, error) {

--- a/pkg/namnsdag/cache.go
+++ b/pkg/namnsdag/cache.go
@@ -21,6 +21,7 @@
 package namnsdag
 
 import (
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,47 +35,92 @@ var (
 	ErrCacheAlreadyCleared = errors.New("cache already cleared")
 )
 
-type cache struct {
-	Day   string `json:"day"`
-	Names []Name `json:"names"`
+// Cache is the model representing the cached data.
+type Cache struct {
+	ETag        string         `json:"etag"`
+	UpdatedAt   time.Time      `json:"updatedAt"`
+	NamesPerDay map[DoM][]Name `json:"namesPerDay"`
 }
 
-type cachev1 struct {
-	Day   string   `json:"day"`
-	Names []string `json:"names"`
+// SetNames replaces the names of the map.
+func (c *Cache) SetNames(names []Name) {
+	c.NamesPerDay = nil
+	c.AddNames(names)
+}
+
+// AddNames adds names to the map of names, on their appropriate dates.
+func (c *Cache) AddNames(names []Name) {
+	if c.NamesPerDay == nil {
+		c.NamesPerDay = make(map[DoM][]Name, len(names))
+	}
+	for _, name := range names {
+		dom := NewDoM(name.Month, name.Day)
+		c.NamesPerDay[dom] = append(c.NamesPerDay[dom], name)
+	}
+}
+
+// DoM (Day-of-Month) represents a day in a month, no matter what year.
+type DoM struct {
+	Day   int
+	Month time.Month
+}
+
+var _ encoding.TextMarshaler = DoM{}
+var _ encoding.TextUnmarshaler = &DoM{}
+
+// MarshalText implements [encoding.TextMarshaler]
+func (d DoM) MarshalText() (text []byte, err error) {
+	return fmt.Appendf(nil, "%02d-%02d", d.Month, d.Day), nil
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler]
+func (d *DoM) UnmarshalText(text []byte) error {
+	_, err := fmt.Sscanf(string(text), "%02d-%02d", &d.Month, &d.Day)
+	return err
+}
+
+// String implements [fmt.Stringer]
+func (d DoM) String() string {
+	b, _ := d.MarshalText()
+	return string(b)
+}
+
+// NewDoMFromTime creates a new [DoM] based on the month and day in the
+// given time. The year, as well as any hours, minutes, seconds, milliseconds,
+// and time zone is ignored.
+func NewDoMFromTime(t time.Time) DoM {
+	_, month, day := t.Date()
+	return NewDoM(month, day)
+}
+
+// NewDoM creates a new [DoM] based on the month and the day.
+func NewDoM(month time.Month, day int) DoM {
+	return DoM{
+		Day:   day,
+		Month: month,
+	}
 }
 
 // LoadCache loads the cached names from ~/.cache/namnsdag/latest.json, or the
 // equivalent in other OS's cache directories (eg. %LOCALAPPDATA%).
 //
 // It will return nil if there is no cache or if the cache is outdated.
-func LoadCache(today time.Time) ([]Name, error) {
+func LoadCache() (Cache, error) {
 	path, err := CacheFile()
 	if err != nil {
-		return nil, fmt.Errorf("get cache file path: %w", err)
+		return Cache{}, fmt.Errorf("get cache file path: %w", err)
 	}
 	fileBytes, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
-		return nil, nil
+		return Cache{}, nil
 	} else if err != nil {
-		return nil, err
+		return Cache{}, err
 	}
-	var cache cache
+	var cache Cache
 	if err := json.Unmarshal(fileBytes, &cache); err != nil {
-		// Maybe v1 cache format
-		var cachev1 cachev1
-		if errv1 := json.Unmarshal(fileBytes, &cachev1); errv1 != nil {
-			// If even that failed, return original error
-			return nil, err
-		}
-		// If cachev1 succeeded, just consider it out of date
-		return nil, nil
+		return Cache{}, err
 	}
-	if cache.Day != today.Format("2006-01-02") {
-		// Cache is out of date
-		return nil, nil
-	}
-	return cache.Names, nil
+	return cache, nil
 }
 
 // SaveCache writes the cached names to ~/.cache/namnsdag/latest.json, or the
@@ -82,7 +128,7 @@ func LoadCache(today time.Time) ([]Name, error) {
 //
 // Today's year, month, and day are used to automatically detect the cache as
 // outdated when loading the cached names.
-func SaveCache(today time.Time, names []Name) error {
+func SaveCache(cache Cache) error {
 	path, err := CacheFile()
 	if err != nil {
 		return fmt.Errorf("get cache file path: %w", err)
@@ -96,11 +142,14 @@ func SaveCache(today time.Time, names []Name) error {
 		return err
 	}
 	defer file.Close()
+
+	if cache.UpdatedAt == (time.Time{}) {
+		cache.UpdatedAt = time.Now()
+	}
+
 	enc := json.NewEncoder(file)
-	return enc.Encode(cache{
-		Day:   today.Format("2006-01-02"),
-		Names: names,
-	})
+	enc.SetIndent("", "  ")
+	return enc.Encode(cache)
 }
 
 // ClearCache will remove the cached names, if any. Returns

--- a/pkg/namnsdag/namnsdag.go
+++ b/pkg/namnsdag/namnsdag.go
@@ -80,10 +80,12 @@ const (
 	GenderNotSet Gender = "NOT_SET"
 )
 
+// Request is the model used for a [Fetch] of names from [URL].
 type Request struct {
 	ETag string
 }
 
+// Response is the data received from a [Fetch] of names from [URL].
 type Response struct {
 	Names []Name
 	ETag  string


### PR DESCRIPTION
- Changed so `pkg/namnsdag` deals with all days, not only today
- Changed so `cache` file stores names for all days, in a map of day-of-month -> names
- Added support for HTTP `etag` for caching. It will still not do HTTP request more than once per day, but subsequent days will use `etag` to try speed things up, both network wise and computational wise.
- Changed module version from v2 to v3
